### PR TITLE
Feat/user controls import

### DIFF
--- a/packages/typechain/package.json
+++ b/packages/typechain/package.json
@@ -8,7 +8,7 @@
     "smartcontract",
     "blockchain"
   ],
-  "version": "8.3.5",
+  "version": "8.3.6",
   "license": "MIT",
   "repository": "https://github.com/ethereum-ts/Typechain",
   "main": "./dist/index.js",

--- a/packages/typechain/package.json
+++ b/packages/typechain/package.json
@@ -8,7 +8,7 @@
     "smartcontract",
     "blockchain"
   ],
-  "version": "8.3.4",
+  "version": "8.3.5",
   "license": "MIT",
   "repository": "https://github.com/ethereum-ts/Typechain",
   "main": "./dist/index.js",

--- a/packages/typechain/package.json
+++ b/packages/typechain/package.json
@@ -8,7 +8,7 @@
     "smartcontract",
     "blockchain"
   ],
-  "version": "8.3.6",
+  "version": "8.3.7",
   "license": "MIT",
   "repository": "https://github.com/ethereum-ts/Typechain",
   "main": "./dist/index.js",

--- a/packages/typechain/src/cli/cli.ts
+++ b/packages/typechain/src/cli/cli.ts
@@ -2,7 +2,7 @@
 import * as prettier from 'prettier'
 
 import { runTypeChain } from '../typechain/runTypeChain'
-import { Config } from '../typechain/types'
+import { CliConfig } from '../typechain/types'
 import { detectInputsRoot } from '../utils/files'
 import { glob } from '../utils/glob'
 import { logger } from '../utils/logger'
@@ -18,7 +18,7 @@ async function main() {
     throw new Error('No files passed.' + '\n' + `\`${cliConfig.files}\` didn't match any input files in ${cwd}`)
   }
 
-  const config: Config = {
+  const config = {
     cwd,
     target: cliConfig.target,
     outDir: cliConfig.outDir,
@@ -30,7 +30,7 @@ async function main() {
       ...cliConfig.flags,
       environment: undefined,
     },
-  }
+  } satisfies CliConfig
 
   const result = await runTypeChain(config)
   // eslint-disable-next-line no-console

--- a/packages/typechain/src/typechain/findTarget.ts
+++ b/packages/typechain/src/typechain/findTarget.ts
@@ -3,9 +3,9 @@ import _, { compact } from 'lodash'
 import { debug } from '../utils/debug'
 import { ensureAbsPath } from '../utils/files/ensureAbsPath'
 import { tryRequire } from '../utils/modules'
-import { Config, TypeChainTarget } from './types'
+import { CliConfig, TypeChainTarget } from './types'
 
-export function findTarget(config: Config): TypeChainTarget {
+export function findTarget(config: CliConfig): TypeChainTarget {
   const target = config.target
   if (!target) {
     throw new Error(`Please provide --target parameter!`)

--- a/packages/typechain/src/typechain/findTarget.ts
+++ b/packages/typechain/src/typechain/findTarget.ts
@@ -12,7 +12,7 @@ export function findTarget(config: CliConfig): TypeChainTarget {
   }
 
   const possiblePaths = [
-    `@typechain/${target}`, // external module
+    `@xlabs-xyz/typechain-${target}`, // external module
     `typechain-target-${target}`, // external module
     ensureAbsPath(target), // path
   ]
@@ -23,7 +23,7 @@ export function findTarget(config: CliConfig): TypeChainTarget {
     throw new Error(
       `Couldn't find ${config.target}. Tried loading: ${compact(possiblePaths).join(
         ', ',
-      )}.\nPerhaps you forgot to install @typechain/${target}?`,
+      )}.\nPerhaps you forgot to install @xlabs-xyz/typechain-${target}?`,
     )
   }
 

--- a/packages/typechain/src/typechain/runTypeChain.ts
+++ b/packages/typechain/src/typechain/runTypeChain.ts
@@ -7,7 +7,7 @@ import { debug } from '../utils/debug'
 import { detectInputsRoot } from '../utils/files'
 import { findTarget } from './findTarget'
 import { loadFileDescriptions, processOutput, skipEmptyAbis } from './io'
-import { CliConfig, CodegenConfig, FileDescription, InMemoryConfig, PublicConfig, PublicInMemoryConfig, Services } from './types'
+import { CliConfig, CodegenConfig, FileDescription, InMemoryConfig, PublicConfig, PublicInMemoryConfig, Services, TypeChainTarget } from './types'
 import { extractAbi } from '../parser/abiParser'
 
 interface Result {
@@ -66,7 +66,7 @@ export async function runTypeChain(publicConfig: PublicConfig): Promise<Result> 
   }
 }
 
-export async function runTypeChainInMemory(publicConfig: PublicInMemoryConfig, fileDescriptions: FileDescription[]): Promise<Result> {
+export async function runTypeChainInMemory(publicConfig: PublicInMemoryConfig, fileDescriptions: FileDescription[], target: TypeChainTarget): Promise<Result> {
   
   const allFiles = (fileDescriptions.filter((fd) => extractAbi(fd.contents).length !== 0)).map(fd => fd.path)
 
@@ -83,8 +83,6 @@ export async function runTypeChainInMemory(publicConfig: PublicInMemoryConfig, f
     mkdirp,
   }
   let filesGenerated = 0
-
-  const {target} = config
 
   debug('Executing beforeRun()')
   filesGenerated += processOutput(services, config, await target.beforeRun())

--- a/packages/typechain/src/typechain/runTypeChain.ts
+++ b/packages/typechain/src/typechain/runTypeChain.ts
@@ -7,7 +7,7 @@ import { debug } from '../utils/debug'
 import { detectInputsRoot } from '../utils/files'
 import { findTarget } from './findTarget'
 import { loadFileDescriptions, processOutput, skipEmptyAbis } from './io'
-import { CliConfig, CodegenConfig, FileDescription, InMemoryConfig, PublicConfig, PublicInMemoryConfig, Services, TypeChainTarget } from './types'
+import { CliConfig, CodegenConfig, Config, FileDescription, InMemoryConfig, PublicConfig, PublicInMemoryConfig, Services, TypeChainTarget } from './types'
 import { extractAbi } from '../parser/abiParser'
 
 interface Result {
@@ -66,8 +66,11 @@ export async function runTypeChain(publicConfig: PublicConfig): Promise<Result> 
   }
 }
 
-export async function runTypeChainInMemory(publicConfig: PublicInMemoryConfig, fileDescriptions: FileDescription[], target: TypeChainTarget): Promise<Result> {
-  
+export async function runTypeChainInMemory(
+  publicConfig: PublicInMemoryConfig,
+  fileDescriptions: FileDescription[],
+  plugin: new (config: Config) => TypeChainTarget
+): Promise<Result> {
   const allFiles = (fileDescriptions.filter((fd) => extractAbi(fd.contents).length !== 0)).map(fd => fd.path)
 
   const config = {
@@ -76,6 +79,7 @@ export async function runTypeChainInMemory(publicConfig: PublicInMemoryConfig, f
     ...publicConfig,
     allFiles,
   } satisfies InMemoryConfig
+  const target = new plugin(config)
 
   const services: Services = {
     fs,

--- a/packages/typechain/src/typechain/types.ts
+++ b/packages/typechain/src/typechain/types.ts
@@ -5,10 +5,8 @@ import { MarkOptional } from 'ts-essentials'
 
 export interface Config {
   cwd: string
-  target: string
   outDir?: string | undefined
   prettier?: object | undefined
-  filesToProcess: string[] // filesToProcess is a subset of allFiles, used during incremental generating
   allFiles: string[]
   /**
    * Optional path to directory with ABI files.
@@ -16,6 +14,15 @@ export interface Config {
    */
   inputDir: string
   flags: CodegenConfig
+}
+
+export interface CliConfig extends Config {
+  target: string
+  filesToProcess: string[] // filesToProcess is a subset of allFiles, used during incremental generating
+}
+
+export interface InMemoryConfig extends Config {
+  target: TypeChainTarget
 }
 
 // @note: these options ale mostly supported only by ethers-v5 target
@@ -27,7 +34,8 @@ export interface CodegenConfig {
   environment: 'hardhat' | undefined
 }
 
-export type PublicConfig = MarkOptional<Config, 'flags' | 'inputDir'>
+export type PublicConfig = MarkOptional<CliConfig, 'flags' | 'inputDir'>
+export type PublicInMemoryConfig = MarkOptional<InMemoryConfig, 'flags' | 'inputDir'>
 
 export abstract class TypeChainTarget {
   public abstract readonly name: string

--- a/packages/typechain/src/typechain/types.ts
+++ b/packages/typechain/src/typechain/types.ts
@@ -21,9 +21,7 @@ export interface CliConfig extends Config {
   filesToProcess: string[] // filesToProcess is a subset of allFiles, used during incremental generating
 }
 
-export interface InMemoryConfig extends Config {
-  target: TypeChainTarget
-}
+export interface InMemoryConfig extends Config {}
 
 // @note: these options ale mostly supported only by ethers-v5 target
 export interface CodegenConfig {


### PR DESCRIPTION
When running Typechain in memory, the user must pass in a conforming class for a Typechain plugin. Thus, the user is responsible for importing a plugin if necessary.